### PR TITLE
feat(groupping): default collapsed state for each group

### DIFF
--- a/dev/app.template.html
+++ b/dev/app.template.html
@@ -17,7 +17,7 @@
 		(onRowClick)="tableState.select($event)" (onRowDoubleClick)="tableState.checkDblClick($event)">
 
 		<ng-container *ngIf="showGroup1">
-			<div [style.padding-left]="10+grLevel*20+'px'" *aGridGroup="let group by 'aaa'; let groupChild=children;let grLevel=groupLevel;let groupCollapsed=collapsed;">
+			<div [style.padding-left]="10+grLevel*20+'px'" *aGridGroup="let group by 'aaa' collapsed true; let groupChild=children;let grLevel=groupLevel;let groupCollapsed=collapsed;">
 				<button (click)="group.toggleCollapse()">{{groupCollapsed?'+':'–'}}</button>
 				{{group.value + ' ('+groupChild.length+') level:'+grLevel}}
 			</div>

--- a/src/aGrid/aGridGroup/aGridGroup.directive.spec.ts
+++ b/src/aGrid/aGridGroup/aGridGroup.directive.spec.ts
@@ -37,6 +37,31 @@ describe('aGridGroup.component', () => {
         expect(result).toEqual(true);
     });
 
+
+    it('collapsed when collapsedDefault', () => {
+        let key = { aaa: 123 };
+
+        instance.collapsedDefault = true;
+
+        expect(instance.isCollapsed(key)).toEqual(true);
+
+        instance.toggleCollapse(key);
+
+        expect(instance.isCollapsed(key)).toEqual(false);
+    });
+
+    it('!collapsed when !collapsedDefault', () => {
+        let key = { aaa: 123 };
+
+        instance.collapsedDefault = false;
+
+        expect(instance.isCollapsed(key)).toEqual(false);
+
+        instance.toggleCollapse(key);
+
+        expect(instance.isCollapsed(key)).toEqual(true);
+    });
+
     it('Can collapse', () => {
         let key = { aaa: 123 };
 

--- a/src/aGrid/aGridGroup/aGridGroup.directive.ts
+++ b/src/aGrid/aGridGroup/aGridGroup.directive.ts
@@ -5,11 +5,18 @@ import { TemplateRef, Directive, Input } from '@angular/core';
 })
 export class AGridGroupDirective {
     @Input('aGridGroupBy') public groupName;
+
+    @Input('aGridGroupCollapsed') public collapsedDefault;
+
     public collapsedGroups: Map<any, boolean> = new Map<any, boolean>();
     constructor(public template: TemplateRef<any>) { }
 
     public isCollapsed(key: any) {
-        return !!this.collapsedGroups.get(key);
+        if (this.collapsedGroups.has(key)) {
+            return !!this.collapsedGroups.get(key);
+        }
+
+        return this.collapsedDefault===true;
     }
 
     public collapse(key: any) {
@@ -21,7 +28,10 @@ export class AGridGroupDirective {
     }
 
     public toggleCollapse(key: any) {
-        let value = this.collapsedGroups.get(key);
+        let value = this.collapsedDefault;
+        if(this.collapsedGroups.has(key)){
+            value = this.collapsedGroups.get(key);
+        }
         this.collapsedGroups.set(key, !value);
     }
 


### PR DESCRIPTION
you can specify default collapsed state for current group by setting *aGridGroup="let group by
'field' collapsed true"